### PR TITLE
adding a few things to radio

### DIFF
--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
-import styles from './RadioButton.module.scss'
+import React, { ReactNode } from 'react';
+import styles from './RadioButton.module.scss';
 
 type RadioButtonPropsT = {
-  value: number | string,
-  groupValue: number | string,
-  checked?: boolean,
-  isDisabled?: boolean,
-  id: string,
-  label: string,
-  groupName: string,
-  classProp?: string
-}
+  value: number | string;
+  groupValue: number | string;
+  checked?: boolean;
+  isDisabled?: boolean;
+  id: string;
+  label?: string;
+  icon?: ReactNode;
+  groupName: string;
+  classProp?: string;
+};
 
 const RadioButton = ({
   label,
@@ -18,10 +19,10 @@ const RadioButton = ({
   groupValue,
   isDisabled = false,
   id,
+  icon,
   groupName,
   classProp = '',
 }: RadioButtonPropsT) => {
-
   return (
     <div className={`${styles.button_wrapper} ${classProp}`}>
       <input
@@ -33,10 +34,13 @@ const RadioButton = ({
         disabled={isDisabled}
         checked={groupValue === value}
       />
-      <label htmlFor={id}>{label}</label>
 
+      {icon}
+
+      {/* Users might want a custom wrapping label  */}
+      {label && <label htmlFor={id}>{label}</label>}
     </div>
-  )
-}
+  );
+};
 
-export default RadioButton
+export default RadioButton;

--- a/src/stories/Radio.stories.tsx
+++ b/src/stories/Radio.stories.tsx
@@ -42,11 +42,8 @@ const Template: ComponentStory<typeof RadioButton> = (args) => {
       <main data-theme="light" style={{ padding: '20px', fontSize: '16px' }}>
         <form>
           <h3>Light Theme - {value}</h3>
-          <fieldset
-            id="sb_radio"
-            onChange={onChange}
-          >
-            {radioFormOptions.map((option,i) => {
+          <fieldset id="sb_radio" onChange={onChange}>
+            {radioFormOptions.map((option, i) => {
               return (
                 <RadioButton
                   groupValue={value}

--- a/src/styles/tools/utility.scss
+++ b/src/styles/tools/utility.scss
@@ -309,7 +309,7 @@ $unit: 'px';
     }
   }
 
-  // Padding: Top
+  // Padding: bottom
   .pb-#{$size} {
     padding-bottom: #{$size}#{$unit};
     &-dt {
@@ -324,7 +324,7 @@ $unit: 'px';
     }
   }
 
-  // Margin: Right
+  // Padding: Right
   .pr-#{$size} {
     padding-right: #{$size}#{$unit};
     &-dt {
@@ -339,7 +339,7 @@ $unit: 'px';
     }
   }
 
-  // Margin: Left
+  // Padding: Left
   .pl-#{$size} {
     padding-left: #{$size}#{$unit};
     &-dt {


### PR DESCRIPTION
why?

the radio form option needs a few more features. It needs the ability to pipe in an icon before the text label and after the radio circle. 

I chose to keep this option to be super flexible just being a React Node. This will let who ever is using this component to pipe whatever they want into the radio button and style it the way they want. 

I also took away the mandatory nature of the label. If the user of the radio component chooses to use their own label and wrap the component ( this is a good way to have a whole section be clickable for the radio) then they would be stuck with two labels. no good. 

<img width="776" alt="Screen Shot 2023-05-11 at 4 22 59 PM" src="https://github.com/mozilla/lilypad/assets/10427235/1bbb3134-3229-47e5-b333-1925765ff8b6">

