### PR TITLE
Version 2.0.5

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -5,14 +5,14 @@ export type AvatarPropsT = {
   src: string;
   alt: string;
   size: number;
-  classProp?: string;
+  className?: string;
 };
 
-const Avatar = ({ src, alt, size = 50, classProp = '' }: AvatarPropsT) => {
+const Avatar = ({ src, alt, size = 50, className = '' }: AvatarPropsT) => {
   const [imageDidError, setImageDidError] = useState(false);
   return (
     <div
-      className={`${styles.avatar} ${classProp}`}
+      className={`${styles.avatar} ${className}`}
       style={{ height: `${size}px`, width: `${size}px` }}
     >
       {imageDidError ? (

--- a/src/components/Badge/Badge.module.scss
+++ b/src/components/Badge/Badge.module.scss
@@ -3,23 +3,22 @@
 .badge {
   &_primary,
   &_secondary {
-    @include primary-font(500);
-    @include font-size(14);
-    line-height: 18px;
-    text-transform: capitalize;
+    font-family: var(--font-primary);
+    font-size: var(--badge-font-size);
+    font-weight: var(--badge-font-size);
+    line-height: var(--badge-line-height);
+    padding: var(--badge-padding);
+    border-radius: var(--badge-border-radius);
     letter-spacing: 0.5px;
-    padding: 5px 12px;
-    border-radius: 56px;
-    height: 28px;
   }
 
   &_primary {
-    background-color: $color-text-main;
-    color: $color-text-reverse;
+    background-color: var(--color-badge-primary-bg);
+    color: var(--color-badge-primary-text);
   }
 
   &_secondary {
-    background-color: $color-interaction-secondary;
-    color: $color-text-subtle;
+    background-color: var(--color-badge-secondary-bg);
+    color: var(--color-badge-secondary-text);
   }
 }

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -6,15 +6,15 @@ export type BadgeCategoriesT = 'primary' | 'secondary';
 export type BadgePropsT = {
   name: string;
   category: BadgeCategoriesT;
-  classProp?: string;
+  className?: string;
 };
 
-const Badge = ({ name, category = 'primary', classProp = '' }: BadgePropsT) => {
+const Badge = ({ name, category = 'primary', className = '' }: BadgePropsT) => {
   return (
     <span
       className={`
        ${styles['badge_' + category]} 
-       ${classProp}`}
+       ${className}`}
     >
       {name}
     </span>

--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -1,9 +1,9 @@
 @use '../../styles/core/boilerplate.scss'as *;
 
 @mixin rect_button_base() {
-  @include primary-font(600);
-  @include font-size(14);
-
+  font-family: var(--font-primary);
+  font-size: var(--button-font-size);
+  font-weight: var(--button-font-weight);
   line-height: 24px;
   border-radius: $button-border-radius;
   box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.05);
@@ -200,26 +200,26 @@
 -------------------------------*/
 
 .small {
-  padding: 6px 12px;
+  padding: var(--button-padding-small);
 
   &_round {
-    padding: 6px;
+    padding: var(--button-padding-small-round);
   }
 }
 
 .medium {
-  padding: 8px 16px;
+  padding: var(--button-padding-medium);
 
   &_round {
-    padding: 8px;
+    padding: var(--button-padding-medium-round);
   }
 }
 
 .large {
-  padding: 12px 18px;
+  padding: var(--button-padding-large);
 
   &_round {
-    padding: 12px;
+    padding: var(--button-padding-large-round);
   }
 }
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -42,7 +42,7 @@ export type ButtonPropsT = {
   href?: string;
   target?: string;
   onClick?: MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
-  classProp?: string;
+  className?: string;
   LinkComponent?: LinkComponentT;
 };
 
@@ -70,7 +70,7 @@ const ButtonIcon = ({
       name={icon}
       color="currentColor"
       size={22}
-      classProp={hasText ? styles[position] : ''}
+      className={hasText ? styles[position] : ''}
     />
   );
 };
@@ -90,7 +90,7 @@ const Button = ({
   iconPlacedRight = false,
   href,
   target = '_self',
-  classProp = '',
+  className = '',
   LinkComponent,
 }: ButtonPropsT) => {
   const content = (
@@ -121,11 +121,11 @@ const Button = ({
   /**
    * Configure CSS Class
    */
-  const className = `
+  const buttonStyle = `
     ${styles['button_' + category]} 
     ${styles[size]} 
     ${!text && styles[size + '_round']} 
-    ${classProp} 
+    ${className} 
     ${active && styles['button_' + category + '_active']}
   `;
 
@@ -133,7 +133,7 @@ const Button = ({
     // To support NextJs Link
     return (
       <LinkComponent
-        className={className}
+        className={buttonStyle}
         href={href}
         onClick={onClick}
         target={target}
@@ -147,7 +147,7 @@ const Button = ({
     // Fall back to a standard <a> tag if LinkComponent is not provided
     return (
       <a
-        className={className}
+        className={buttonStyle}
         id={id}
         target={target}
         href={href}
@@ -160,7 +160,7 @@ const Button = ({
   // Button logic remains unchanged
   return (
     <button
-      className={className}
+      className={buttonStyle}
       id={id}
       aria-label={label ? label : text}
       type={type}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -36,7 +36,8 @@ export type ButtonPropsT = {
   category?: ButtonCategoriesT;
   size?: ButtonSizesT;
   disabled?: boolean;
-  icon?: IconT | React.ReactNode;
+  icon?: IconT;
+  customIcon?: React.ReactNode;
   iconPlacedRight?: boolean;
   href?: string;
   target?: string;
@@ -46,17 +47,27 @@ export type ButtonPropsT = {
 };
 
 type ButtonIconT = {
-  icon: IconT | React.ReactNode;
+  icon?: IconT;
+  customIcon?: React.ReactNode;
   hasText: boolean;
   position: 'left' | 'right';
 };
 
-const ButtonIcon = ({ icon, hasText, position = 'left' }: ButtonIconT) => {
-  if (typeof icon !== 'string') return <>{icon}</>;
+const ButtonIcon = ({
+  icon,
+  customIcon,
+  hasText,
+  position = 'left',
+}: ButtonIconT) => {
+  if (customIcon) return <>{customIcon}</>;
+
+  if (!icon) {
+    return <></>;
+  }
 
   return (
     <Icon
-      name={icon as IconT}
+      name={icon}
       color="currentColor"
       size={22}
       classProp={hasText ? styles[position] : ''}
@@ -74,6 +85,7 @@ const Button = ({
   size = 'medium',
   disabled,
   icon,
+  customIcon,
   onClick,
   iconPlacedRight = false,
   href,
@@ -83,8 +95,9 @@ const Button = ({
 }: ButtonPropsT) => {
   const content = (
     <>
-      {!iconPlacedRight && icon && (
+      {!iconPlacedRight && (
         <ButtonIcon
+          customIcon={customIcon}
           icon={icon}
           hasText={Boolean(text?.length)}
           position="left"
@@ -94,8 +107,9 @@ const Button = ({
       {/* Button Text  */}
       {text}
 
-      {iconPlacedRight && icon && (
+      {iconPlacedRight && (
         <ButtonIcon
+          customIcon={customIcon}
           icon={icon}
           hasText={Boolean(text?.length)}
           position="right"

--- a/src/components/Checkbox/Checkbox.module.scss
+++ b/src/components/Checkbox/Checkbox.module.scss
@@ -7,10 +7,7 @@
   align-items: center;
   position: relative;
   cursor: pointer;
-  &,
-  & * {
-    box-sizing: border-box;
-  }
+  box-sizing: content-box;
 
   /* Hide the browser's default checkbox */
   input {
@@ -42,8 +39,9 @@
 }
 
 .label {
-  @include font-size(16);
-  @include primary-font();
+  font-family: var(--font-primary);
+  font-size: var(--checkbox-label-font-size);
+  font-weight: var(--checkbox-label-font-weight);
   color: $color-text-main;
   padding-left: 16px;
 }
@@ -69,8 +67,8 @@
     content: '';
     position: absolute;
     display: none;
-    left: 6px;
-    top: 1px;
+    left: 7px;
+    top: 2px;
     width: 5px;
     height: 11px;
     border: solid $color-text-reverse;

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -11,19 +11,19 @@ type CheckboxPropsT = {
   label?: string | ReactNode;
   checked?: boolean;
   disabled?: boolean;
-  classProp?: string;
-  labelClassProp?: string;
+  className?: string;
+  labelclassName?: string;
   onChange: (value: boolean) => void;
 };
 
 const Checkbox = forwardRef(
   (
     {
-      classProp = '',
+      className = '',
       label,
       disabled,
       checked,
-      labelClassProp = '',
+      labelclassName = '',
       onChange,
     }: CheckboxPropsT,
     ref
@@ -42,7 +42,7 @@ const Checkbox = forwardRef(
     };
 
     return (
-      <label className={`${classProp} ${styles.container}`}>
+      <label className={`${className} ${styles.container}`}>
         <input
           onChange={handleOnChange}
           type="checkbox"
@@ -59,7 +59,7 @@ const Checkbox = forwardRef(
         />
 
         {label ? (
-          <div className={`${styles.label} ${labelClassProp}`}>{label}</div>
+          <div className={`${styles.label} ${labelclassName}`}>{label}</div>
         ) : null}
       </label>
     );

--- a/src/components/CopyButton/CopyButton.module.scss
+++ b/src/components/CopyButton/CopyButton.module.scss
@@ -1,9 +1,10 @@
 @use '../../styles/core/boilerplate.scss'as *;
 
 .success {
-  @include primary-font(500);
-  @include font-size(16);
+  font-family: var(--font-primary);
+  font-size: var(--copy-button-font-size);
+  font-weight: var(--copy-button-font-weight);
   line-height: 24px;
-  color: $color-text-subtle;
+  color: var(--copy-button-text-color);
   padding: 8px;
 }

--- a/src/components/CopyButton/CopyButton.tsx
+++ b/src/components/CopyButton/CopyButton.tsx
@@ -6,14 +6,14 @@ export type CopyButtonPropsT = {
   onClick?: Function;
   successMessage?: string;
   value: string | number;
-  classProp?: string;
+  className?: string;
 };
 
 const CopyButton = ({
   onClick,
   successMessage = 'Copied!',
   value,
-  classProp = '',
+  className = '',
 }: CopyButtonPropsT) => {
   const [success, setSuccess] = useState<boolean>(false);
 
@@ -40,7 +40,7 @@ const CopyButton = ({
       ) : (
         <Button
           label="copy"
-          classProp={classProp}
+          className={className}
           onClick={handleClick}
           icon="copy"
           size="small"

--- a/src/components/Dropdown/Dropdown.module.scss
+++ b/src/components/Dropdown/Dropdown.module.scss
@@ -6,10 +6,11 @@
 }
 
 .content_wrapper {
-  border-radius: 4px;
+  border-radius: var(--dropdown-border-radius);
   z-index: 1;
-  background-color: $color-background-neutral-0;
-  box-shadow: $drop-shadow;
+  background-color: var(--color-background-neutral-0);
+  box-shadow: var(--drop-shadow);
+  margin-top: var(--dropdown-margin-top);
 }
 
 .left {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -22,11 +22,19 @@ type DropdownProps = {
   classProp?: string;
   alignment?: AlignmentT;
   width?: number;
+  selfClose?: boolean;
 };
 
 const Dropdown = forwardRef(
   (
-    { cta, content, width = 320, alignment, classProp = '' }: DropdownProps,
+    {
+      cta,
+      content,
+      width = 320,
+      alignment,
+      selfClose = true,
+      classProp = '',
+    }: DropdownProps,
     ref
   ) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -88,6 +96,9 @@ const Dropdown = forwardRef(
             className={`${styles.content_wrapper} ${
               alignment === 'right' ? styles.right : styles.left
             }`}
+            onClick={() => {
+              if (selfClose) closeDropdown();
+            }}
           >
             {content}
           </div>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -11,15 +11,15 @@ import {
 import styles from './Dropdown.module.scss';
 import FadeIn from '../FadeIn';
 
-export type dropdownT = {
+export type DropdownT = {
   closeDropdown: Function;
 };
 
 export type AlignmentT = 'left' | 'right';
-type DropdownProps = {
+type DropdownPropsT = {
   cta: ReactNode;
   content: ReactNode;
-  classProp?: string;
+  className?: string;
   alignment?: AlignmentT;
   width?: number;
   selfClose?: boolean;
@@ -33,8 +33,8 @@ const Dropdown = forwardRef(
       width = 320,
       alignment,
       selfClose = true,
-      classProp = '',
-    }: DropdownProps,
+      className = '',
+    }: DropdownPropsT,
     ref
   ) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -84,7 +84,7 @@ const Dropdown = forwardRef(
     return (
       <div
         ref={containerRef}
-        className={`${classProp} ${styles.dropdown_wrapper}`}
+        className={`${className} ${styles.dropdown_wrapper}`}
       >
         {/* CTA */}
         <div onClick={onToggleClick}>{cta}</div>

--- a/src/components/Dropdown/index.ts
+++ b/src/components/Dropdown/index.ts
@@ -1,1 +1,1 @@
-export { default, type AlignmentT, type dropdownT } from './Dropdown';
+export { default, type AlignmentT, type DropdownT } from './Dropdown';

--- a/src/components/FadeIn/FadeIn.tsx
+++ b/src/components/FadeIn/FadeIn.tsx
@@ -15,7 +15,7 @@ type FadeInPropsT = {
   animation?: string;
   onComplete?: () => void;
   children: ReactNode;
-  classProp?: string;
+  className?: string;
 };
 
 const FadeIn = ({
@@ -23,7 +23,7 @@ const FadeIn = ({
   onComplete,
   animation,
   children,
-  classProp = '',
+  className = '',
 }: FadeInPropsT) => {
   const [isOpen, setIsOpen] = useState<boolean>(visible);
   const [isVisible, setIsVisible] = useState<boolean>(visible);
@@ -51,7 +51,7 @@ const FadeIn = ({
       isVisible={isOpen}
       onComplete={handleOnComplete}
       animation={animation}
-      classProp={classProp}
+      className={className}
     >
       {Children.map(arrayChildren, (child, i) => {
         return isVisible && <>{child}</>;
@@ -69,7 +69,7 @@ type FadeContentsPropsT = {
   animation?: string;
   onComplete: () => void;
   children: ReactNode;
-  classProp?: string;
+  className?: string;
 };
 
 const FadeContents = ({
@@ -77,7 +77,7 @@ const FadeContents = ({
   onComplete,
   children,
   animation = 'translateY(20px)',
-  classProp = '',
+  className = '',
 }: PropsWithChildren<FadeContentsPropsT>) => {
   const [maxIsVisible, setMaxIsVisible] = useState(0);
   const arrayChildren = Children.toArray(children);
@@ -111,7 +111,7 @@ const FadeContents = ({
   }, [maxIsVisible, isVisible, onComplete, arrayChildren]);
 
   return (
-    <div className={`${classProp}`}>
+    <div className={`${className}`}>
       {Children.map(arrayChildren, (child, i) => {
         return (
           <div

--- a/src/components/HubIcon/HubIcon.tsx
+++ b/src/components/HubIcon/HubIcon.tsx
@@ -13,18 +13,18 @@ type HubIconPropsT = {
   name: HubIconT;
   color?: string;
   size?: number;
-  classProp?: string;
+  className?: string;
 };
 
 const HubIcon = ({
   name,
   color = '#000000',
   size = 20,
-  classProp = '',
+  className = '',
 }: HubIconPropsT) => {
   return (
     <svg
-      className={classProp}
+      className={className}
       width={size}
       height={size}
       fill="none"

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -297,18 +297,18 @@ type IconProps = {
   name: IconT;
   color?: string;
   size?: number;
-  classProp?: string;
+  className?: string;
 };
 
 const Icon = ({
   name,
   color = '#000000',
   size = 20,
-  classProp = '',
+  className = '',
 }: IconProps) => {
   return (
     <svg
-      className={classProp}
+      className={className}
       width={size}
       height={size}
       fill="none"

--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -2,21 +2,21 @@
 
 .input {
   &_wrapper {
-    @include primary-font();
+    font-family: var(--font-primary);
     display: flex;
     position: relative;
     flex-direction: column;
     width: 100%;
 
     label {
-      @include font-size(16);
-      color: $color-text-main;
+      font-size: var(--input-label-font-size);
+      color: var(--color-text-main);
       line-height: 24px;
       margin-bottom: 6px;
-      font-weight: 600;
+      font-weight: var(--input-label-font-weight);
 
       span {
-        color: $color-semantic-critical;
+        color: var(--color-semantic-critical);
       }
     }
   }
@@ -27,15 +27,16 @@
     flex-direction: column;
 
     input {
-      @include font-size(16);
-      color: $color-text-main;
-      border: $color-border-1 solid 2px;
-      border-radius: 12px;
-      padding: 12px;
+      font-size: var(--input-font-size);
+      color: var(--color-text-main);
+      border: var(--color-border-1) solid 2px;
+      border-radius: var(--input-border-radius);
+      padding: var(--input-padding);
       font-family: inherit;
+      background-color: var(--color-background-neutral-0);
 
       &.has_error {
-        border: $color-semantic-critical solid 2px;
+        border: var(--color-semantic-critical) solid 2px;
       }
 
       &.has_icon {
@@ -46,7 +47,7 @@
 
   &_error {
     input {
-      border: $color-semantic-critical solid 1px;
+      border: var(--color-semantic-critical) solid 1px;
     }
   }
 }
@@ -54,7 +55,7 @@
 .tool_tip {
   margin-left: 10px;
   svg {
-    stroke: $color-interactions-menu;
+    stroke: var(--color-interactions-menu);
   }
 }
 
@@ -63,16 +64,16 @@
 }
 
 .error_message {
-  @include font-size(16);
-  color: $color-semantic-critical;
+  font-size: var(--input-info-font-size);
+  color: var(--color-semantic-critical);
   margin-top: 6px;
   line-height: 24px;
 }
 
 .info {
-  @include font-size(16);
+  font-size: var(--input-info-font-size);
   margin-top: 6px;
-  color: $color-text-subtle;
+  color: var(--color-text-subtle);
   line-height: 24px;
 }
 
@@ -84,15 +85,15 @@
 
 .icon_success {
   @include icon();
-  stroke: $color-semantic-success;
+  stroke: var(--color-semantic-success);
 }
 
 .icon_error {
   @include icon();
-  stroke: $color-semantic-critical;
+  stroke: var(--color-semantic-critical);
 }
 
 .icon_default {
   @include icon();
-  stroke: $color-text-info;
+  stroke: var(--color-text-info);
 }

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -45,6 +45,7 @@ type InputProps = {
   info?: string;
   validator?: Function;
   required?: boolean;
+  showRequired?: boolean;
   isError?: boolean;
   customErrorMessage?: string;
   pattern?: string;
@@ -76,6 +77,7 @@ const Input = forwardRef(
       onFocus,
       validator = () => true,
       required = false,
+      showRequired = true,
       isError,
       customErrorMessage,
       pattern,
@@ -187,7 +189,7 @@ const Input = forwardRef(
         {showLabel && (
           <label className={styles.label}>
             {label}
-            <span> {required ? '*' : ''}</span>
+            <span> {required && showRequired ? '*' : ''}</span>
             {toolTip && (
               <ToolTip description={toolTip} classProp={styles.tool_tip}>
                 <Icon name="info" />

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -61,7 +61,7 @@ type InputProps = {
   onFocus?: Function;
   onChange?: Function;
   mask?: RegExp;
-  classProp?: string;
+  className?: string;
 };
 
 const Input = forwardRef(
@@ -91,7 +91,7 @@ const Input = forwardRef(
       showLabel = true,
       onBlur,
       mask,
-      classProp = '',
+      className = '',
     }: InputProps,
     ref
   ) => {
@@ -184,14 +184,14 @@ const Input = forwardRef(
       <div
         className={`${styles.input_wrapper}  ${
           showError ? styles.input_error : null
-        } ${classProp}`}
+        } ${className}`}
       >
         {showLabel && (
           <label className={styles.label}>
             {label}
             <span> {required && showRequired ? '*' : ''}</span>
             {toolTip && (
-              <ToolTip description={toolTip} classProp={styles.tool_tip}>
+              <ToolTip description={toolTip} className={styles.tool_tip}>
                 <Icon name="info" />
               </ToolTip>
             )}
@@ -221,7 +221,7 @@ const Input = forwardRef(
           />
 
           {icon ? (
-            <Icon name={icon} classProp={styles['icon_' + iconColor]} />
+            <Icon name={icon} className={styles['icon_' + iconColor]} />
           ) : null}
         </div>
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -19,7 +19,7 @@ type ModalPropsT = {
   zIndex?: number;
   isBackdropClickDisabled?: boolean;
   onClose: MouseEventHandler<HTMLDivElement>;
-  classProp?: string;
+  className?: string;
 };
 
 const Modal = ({
@@ -29,7 +29,7 @@ const Modal = ({
   zIndex = 10,
   isBackdropClickDisabled = false,
   onClose,
-  classProp = '',
+  className = '',
 }: ModalPropsT) => {
   const ref = useRef<Element | null>(null);
   const [mounted, setMounted] = useState(false);
@@ -95,7 +95,7 @@ const Modal = ({
         >
           <div id="backdropContainer" className={styles.backdrop_container}>
             <div
-              className={`${classProp} ${
+              className={`${className} ${
                 hasContainer && styles.modal_container
               } `}
             >

--- a/src/components/Notification/CrumbMessage.tsx
+++ b/src/components/Notification/CrumbMessage.tsx
@@ -13,7 +13,7 @@ export type CrumbPropsT = {
   mouseEnter: () => void;
   mouseLeave: () => void;
   close: () => void;
-  classProp?: string;
+  className?: string;
 };
 
 const CrumbMessage = forwardRef(
@@ -26,13 +26,13 @@ const CrumbMessage = forwardRef(
       mouseEnter,
       mouseLeave,
       close,
-      classProp = '',
+      className = '',
     }: CrumbPropsT,
     ref: ForwardedRef<HTMLDivElement>
   ) => {
     return (
       <div
-        className={`${classProp} ${styles.container} ${styles[type]}`}
+        className={`${className} ${styles.container} ${styles[type]}`}
         ref={ref}
         onMouseEnter={mouseEnter}
         onMouseLeave={mouseLeave}
@@ -41,7 +41,7 @@ const CrumbMessage = forwardRef(
           (icon ? (
             <CustomIcon type={type} icon={icon} />
           ) : (
-            <NotificationIcon type={type} classProp="pl-12" />
+            <NotificationIcon type={type} className="pl-12" />
           ))}
 
         {/* CRUMB DISPLAYS MAX 30 CHARACTERS - USE TOAST IF YOU NEED MORE  */}

--- a/src/components/Notification/CrumbMessage.tsx
+++ b/src/components/Notification/CrumbMessage.tsx
@@ -41,7 +41,7 @@ const CrumbMessage = forwardRef(
           (icon ? (
             <CustomIcon type={type} icon={icon} />
           ) : (
-            <NotificationIcon type={type} className="pl-12" />
+            <NotificationIcon type={type} className="pl-12px" />
           ))}
 
         {/* CRUMB DISPLAYS MAX 30 CHARACTERS - USE TOAST IF YOU NEED MORE  */}

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -4,7 +4,7 @@ import styles from './Notification.module.scss';
 import NotificationMessage from './NotificationMessage';
 
 export type NotificationPropsT = {
-  classProp?: string;
+  className?: string;
 };
 
 export type NotificationInterfaceT = {
@@ -16,7 +16,7 @@ export interface NotificationI extends NewNotificationT {
 }
 
 const Notification = forwardRef(
-  ({ classProp = '' }: NotificationPropsT, ref) => {
+  ({ className = '' }: NotificationPropsT, ref) => {
     const [notifications, setNotifications] = useState<NotificationI[]>([]);
 
     /**
@@ -107,7 +107,7 @@ const Notification = forwardRef(
     );
 
     return (
-      <div id="lily_notification" className={classProp}>
+      <div id="lily_notification" className={className}>
         {/* TOP CENTER  */}
         {Boolean(topCenterNotifications.length) && (
           <div className={styles.top_center}>

--- a/src/components/Notification/NotificationIcon.tsx
+++ b/src/components/Notification/NotificationIcon.tsx
@@ -4,21 +4,21 @@ import { InfoIcon, SuccessIcon, WarningIcon, ErrorIcon } from './icons';
 
 type NotificationIconPropsT = {
   type: NotificationTypesT;
-  classProp?: string;
+  className?: string;
 };
 
-const NotificationIcon = ({ type, classProp }: NotificationIconPropsT) => {
+const NotificationIcon = ({ type, className }: NotificationIconPropsT) => {
   switch (type) {
     case 'info':
-      return <InfoIcon classProp={classProp} />;
+      return <InfoIcon className={className} />;
     case 'success':
-      return <SuccessIcon classProp={classProp} />;
+      return <SuccessIcon className={className} />;
     case 'warning':
-      return <WarningIcon classProp={classProp} />;
+      return <WarningIcon className={className} />;
     case 'error':
-      return <ErrorIcon classProp={classProp} />;
+      return <ErrorIcon className={className} />;
     default:
-      return <InfoIcon classProp={classProp} />;
+      return <InfoIcon className={className} />;
   }
 };
 

--- a/src/components/Notification/NotificationMessage.tsx
+++ b/src/components/Notification/NotificationMessage.tsx
@@ -26,7 +26,7 @@ export type NotificationMessagePropsT = {
   hasIcon?: boolean;
   category?: CategoryT;
   icon?: IconT;
-  classProp?: string;
+  className?: string;
 };
 
 const NotificationMessage = ({

--- a/src/components/Notification/ToastMessage.tsx
+++ b/src/components/Notification/ToastMessage.tsx
@@ -56,11 +56,11 @@ const ToastMessage = forwardRef(
         />
         <div className="flex">
           <div className={styles.icons}>
-            <NotificationIcon type={type} className="mr-20" />
+            <NotificationIcon type={type} className="mr-20px" />
           </div>
-          <div className="mr-20">
+          <div className="mr-20px">
             <div className="heading-xs">{title}</div>
-            <p className="body-md my-16-dt my-14-mb">{description}</p>
+            <p className="body-md my-16px-dt my-14px-mb">{description}</p>
             {callback && (
               <div className={styles.callback_wrapper}>
                 <Button

--- a/src/components/Notification/ToastMessage.tsx
+++ b/src/components/Notification/ToastMessage.tsx
@@ -14,7 +14,7 @@ export type ToastPropsT = {
   mouseLeave: () => void;
   close: () => void;
   progressBar?: ReactNode;
-  classProp?: string;
+  className?: string;
 };
 
 const ToastMessage = forwardRef(
@@ -29,7 +29,7 @@ const ToastMessage = forwardRef(
       mouseLeave,
       close,
       progressBar,
-      classProp = '',
+      className = '',
     }: ToastPropsT,
     ref: ForwardedRef<HTMLDivElement>
   ) => {
@@ -42,7 +42,7 @@ const ToastMessage = forwardRef(
 
     return (
       <div
-        className={`${classProp} ${styles.container} ${styles[type]}`}
+        className={`${className} ${styles.container} ${styles[type]}`}
         ref={ref}
         onMouseEnter={mouseEnter}
         onMouseLeave={mouseLeave}
@@ -50,13 +50,13 @@ const ToastMessage = forwardRef(
         <Button
           onClick={close}
           icon="x"
-          classProp={styles.close}
+          className={styles.close}
           label="close"
           category="primary_clear"
         />
         <div className="flex">
           <div className={styles.icons}>
-            <NotificationIcon type={type} classProp="mr-20" />
+            <NotificationIcon type={type} className="mr-20" />
           </div>
           <div className="mr-20">
             <div className="heading-xs">{title}</div>

--- a/src/components/Notification/icons/CustomIcon.tsx
+++ b/src/components/Notification/icons/CustomIcon.tsx
@@ -11,7 +11,7 @@ type InfoIconPropsT = {
 
 const CustomIcon = ({ icon, type }: InfoIconPropsT) => {
   return (
-    <div className={`pl-12 flex ${styles['custom-' + type]}`}>
+    <div className={`pl-12px flex ${styles['custom-' + type]}`}>
       <Icon name={icon} size={24} color="currentColor" />
     </div>
   );

--- a/src/components/Notification/icons/CustomIcon.tsx
+++ b/src/components/Notification/icons/CustomIcon.tsx
@@ -6,7 +6,7 @@ import styles from './icon.module.scss';
 type InfoIconPropsT = {
   icon: IconT;
   type: NotificationTypesT;
-  classProp?: string;
+  className?: string;
 };
 
 const CustomIcon = ({ icon, type }: InfoIconPropsT) => {

--- a/src/components/Notification/icons/ErrorIcon.tsx
+++ b/src/components/Notification/icons/ErrorIcon.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import styles from './icon.module.scss';
 
 type InfoIconPropsT = {
-  classProp?: string;
+  className?: string;
 };
 
-const ErrorIcon = ({ classProp }: InfoIconPropsT) => {
+const ErrorIcon = ({ className }: InfoIconPropsT) => {
   return (
     <svg
-      className={classProp}
+      className={className}
       width="30"
       height="30"
       viewBox="0 0 30 30"

--- a/src/components/Notification/icons/InfoIcon.tsx
+++ b/src/components/Notification/icons/InfoIcon.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import styles from './icon.module.scss';
 
 type InfoIconPropsT = {
-  classProp?: string;
+  className?: string;
 };
 
-const SuccessIcon = ({ classProp }: InfoIconPropsT) => {
+const SuccessIcon = ({ className }: InfoIconPropsT) => {
   return (
     <svg
-      className={classProp}
+      className={className}
       width="30"
       height="30"
       viewBox="0 0 30 30"

--- a/src/components/Notification/icons/SuccessIcon.tsx
+++ b/src/components/Notification/icons/SuccessIcon.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import styles from './icon.module.scss';
 
 type InfoIconPropsT = {
-  classProp?: string;
+  className?: string;
 };
 
-const SuccessIcon = ({ classProp }: InfoIconPropsT) => {
+const SuccessIcon = ({ className }: InfoIconPropsT) => {
   return (
     <svg
-      className={classProp}
+      className={className}
       width="30"
       height="30"
       viewBox="0 0 30 30"

--- a/src/components/Notification/icons/WarningIcon.tsx
+++ b/src/components/Notification/icons/WarningIcon.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import styles from './icon.module.scss';
 
 type InfoIconPropsT = {
-  classProp?: string;
+  className?: string;
 };
 
-const WarningIcon = ({ classProp }: InfoIconPropsT) => {
+const WarningIcon = ({ className }: InfoIconPropsT) => {
   return (
     <svg
-      className={classProp}
+      className={className}
       width="30"
       height="30"
       viewBox="0 0 30 30"

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -4,15 +4,15 @@ import styles from './Pill.module.scss';
 export type PillPropsT = {
   title: string;
   category: 'primary' | 'secondary' | 'rainbow' | 'warm' | 'cool';
-  classProp?: string;
+  className?: string;
 };
 
-const Pill = ({ title, category = 'primary', classProp = '' }: PillPropsT) => {
+const Pill = ({ title, category = 'primary', className = '' }: PillPropsT) => {
   return (
     <span
       className={`
        ${styles['pill_' + category]} 
-       ${classProp}`}
+       ${className}`}
     >
       {title}
     </span>

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -3,15 +3,22 @@ import styles from './ProgressBar.module.scss';
 
 export type ProgressBarPropsT = {
   value: number;
-  classProp?: string;
+  className?: string;
   classValueProp?: string;
 };
 
-const ProgressBar = ({ value = 40, classProp = '', classValueProp = ''}: ProgressBarPropsT) => {
+const ProgressBar = ({
+  value = 40,
+  className = '',
+  classValueProp = '',
+}: ProgressBarPropsT) => {
   return (
-    <div className={`${styles.wrapper} ${classProp}`}>
+    <div className={`${styles.wrapper} ${className}`}>
       <div className={styles.container}></div>
-      <div className={`${styles.value} ${classValueProp}`} style={{ width: value + '%' }}></div>
+      <div
+        className={`${styles.value} ${classValueProp}`}
+        style={{ width: value + '%' }}
+      ></div>
     </div>
   );
 };

--- a/src/components/RadioButton/RadioButton.module.scss
+++ b/src/components/RadioButton/RadioButton.module.scss
@@ -47,8 +47,9 @@
     }
 
     label {
-      @include primary-font(500);
-      @include font-size(16);
+      font-family: var(--font-primary);
+      font-size: var(--radio-label-font-size);
+      font-weight: var(--radio-label-font-weight);
       color: $color-text-main;
       margin-left: 16px;
     }

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -10,7 +10,7 @@ type RadioButtonPropsT = {
   label?: string;
   icon?: ReactNode;
   groupName: string;
-  classProp?: string;
+  className?: string;
 };
 
 const RadioButton = ({
@@ -21,10 +21,10 @@ const RadioButton = ({
   id,
   icon,
   groupName,
-  classProp = '',
+  className = '',
 }: RadioButtonPropsT) => {
   return (
-    <div className={`${styles.button_wrapper} ${classProp}`}>
+    <div className={`${styles.button_wrapper} ${className}`}>
       <input
         readOnly={true}
         id={id}

--- a/src/components/Select/Select.module.scss
+++ b/src/components/Select/Select.module.scss
@@ -2,7 +2,7 @@
 
 .select {
   &_wrapper {
-    @include primary-font();
+    font-family: var(--font-primary);
     display: flex;
     position: relative;
     flex-direction: column;
@@ -10,30 +10,30 @@
     position: relative;
 
     label {
-      @include font-size(16);
-      color: $color-text-main;
+      font-size: var(--input-label-font-size);
+      color: var(--color-text-main);
       line-height: 24px;
       margin-bottom: 6px;
-      font-weight: 600;
+      font-weight: var(--input-label-font-weight);
 
       span {
-        color: $color-semantic-critical;
+        color: var(--color-semantic-critical);
       }
     }
 
     select {
-      @include font-size(16);
-      color: $color-text-main;
-      border: $color-border-1 solid 2px;
-      border-radius: 12px;
-      padding: 12px;
+      font-size: var(--input-font-size);
+      color: var(--color-text-main);
+      border: var(--color-border-1) solid 2px;
+      border-radius: var(--input-border-radius);
+      padding: var(--input-padding);
       background: transparent;
       appearance: none;
       background-color: transparent;
       z-index: 1;
 
       &.has_error {
-        border: $color-semantic-critical solid 2px;
+        border: var(--color-semantic-critical) solid 2px;
       }
 
       &.has_icon {
@@ -46,14 +46,14 @@
     position: relative;
     width: 100%;
     display: flex;
-    background-color: $color-neutral-0;
+    background-color: var(--color-neutral-0);
     flex-direction: column;
     border-radius: 12px;
   }
 
   &_error {
     select {
-      border: $color-semantic-critical solid 1px;
+      border: var(--color-semantic-critical) solid 1px;
     }
   }
 }
@@ -62,19 +62,19 @@
   position: absolute;
   right: 14px;
   top: 13px;
-  stroke: $color-interactions-menu;
+  stroke: var(--color-interactions-menu);
 }
 
 .error_message {
-  @include font-size(16);
-  color: $color-semantic-critical;
+  font-size: var(--input-info-font-size);
+  color: var(--color-semantic-critical);
   margin-top: 6px;
   line-height: 24px;
 }
 
 .info {
-  @include font-size(16);
+  font-size: var(--input-info-font-size);
   margin-top: 6px;
-  color: $color-text-subtle;
+  color: var(--color-text-subtle);
   line-height: 24px;
 }

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -27,7 +27,7 @@ type SelectPropsT = {
   options: OptionT[];
   name: string;
   info?: string;
-  classProp?: string;
+  className?: string;
   onBlur?: Function;
   onFocus?: Function;
   onChange?: Function;
@@ -48,7 +48,7 @@ const Select = forwardRef(
       name,
       options,
       info = '',
-      classProp = '',
+      className = '',
       onChange,
       onBlur,
       onFocus,
@@ -150,7 +150,7 @@ const Select = forwardRef(
       <div
         className={`${styles.select_wrapper}  ${
           showError ? styles.select_error : null
-        } ${classProp}`}
+        } ${className}`}
       >
         {showLabel && (
           <label htmlFor={id}>
@@ -178,7 +178,7 @@ const Select = forwardRef(
               );
             })}
           </select>
-          <Icon classProp={styles.arrow} name="chevron-down" />
+          <Icon className={styles.arrow} name="chevron-down" />
         </div>
 
         {/* Error Message */}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -33,6 +33,7 @@ type SelectPropsT = {
   onChange?: Function;
   validator?: Function;
   required?: boolean;
+  showRequired?: boolean;
   showLabel?: boolean;
   isError?: boolean;
   customErrorMessage?: string;
@@ -53,6 +54,7 @@ const Select = forwardRef(
       onFocus,
       validator = () => true,
       required = false,
+      showRequired = true,
       showLabel = true,
       isError,
       customErrorMessage,
@@ -153,7 +155,7 @@ const Select = forwardRef(
         {showLabel && (
           <label htmlFor={id}>
             {label}
-            <span> {required ? '*' : ''}</span>
+            <span> {required && showRequired ? '*' : ''}</span>
           </label>
         )}
 

--- a/src/components/Switch/Switch.module.scss
+++ b/src/components/Switch/Switch.module.scss
@@ -10,11 +10,11 @@
     }
 
     .track_on {
-      background: $color-semantic-success-hover; 
+      background: $color-semantic-success-hover;
     }
 
     .track_off {
-      background: $color-semantic-neutral-hover; 
+      background: $color-semantic-neutral-hover;
     }
   }
 
@@ -33,7 +33,7 @@
     @include body-md();
     color: $color-text-main;
     line-height: 24px;
-    font-weight: 600;
+    font-weight: var(--switch-font-weight);
     margin-left: 12px;
   }
 }
@@ -52,7 +52,7 @@
 .track {
   &_on {
     @include track;
-    background: $color-semantic-success; 
+    background: $color-semantic-success;
   }
 
   &_off {

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -15,7 +15,7 @@ export type SwitchPropsT = {
   icon?: IconT;
   iconOn?: IconT; // Note: to use "iconOn", "icon" needs to have a value.
   hasIcon?: boolean;
-  classProp?: string;
+  className?: string;
 };
 
 export type switchT = {
@@ -32,7 +32,7 @@ const Switch = forwardRef(
       iconOn = 'check',
       hasIcon = true,
       onChange,
-      classProp = '',
+      className = '',
     }: SwitchPropsT,
     ref
   ) => {
@@ -75,7 +75,7 @@ const Switch = forwardRef(
     };
 
     return (
-      <div className={`${classProp} ${styles.wrapper}`}>
+      <div className={`${className} ${styles.wrapper}`}>
         <button
           aria-label={label}
           role="switch"
@@ -88,7 +88,7 @@ const Switch = forwardRef(
               <div className={styles.handle_shadow}></div>
               {currentIcon && hasIcon && (
                 <Icon
-                  classProp={isOn ? styles.icon_on : styles.icon_off}
+                  className={isOn ? styles.icon_on : styles.icon_off}
                   size={16}
                   name={currentIcon}
                 />

--- a/src/components/TextArea/TextArea.module.scss
+++ b/src/components/TextArea/TextArea.module.scss
@@ -2,21 +2,21 @@
 
 .text_area {
   &_wrapper {
-    @include primary-font();
+    font-family: var(--font-primary);
     display: flex;
     position: relative;
     flex-direction: column;
     width: 100%;
 
     label {
-      @include font-size(16);
-      color: $color-text-main;
+      font-size: var(--input-label-font-size);
+      color: var(--color-text-main);
       line-height: 24px;
       margin-bottom: 6px;
-      font-weight: 600;
+      font-weight: var(--input-label-font-weight);
 
       span {
-        color: $color-semantic-critical;
+        color: var(--color-semantic-critical);
       }
     }
   }
@@ -27,16 +27,16 @@
     flex-direction: column;
 
     textarea {
-      @include font-size(16);
+      font-size: var(--input-font-size);
       font-family: inherit;
-      color: $color-text-main;
-      border: $color-border-1 solid 2px;
-      border-radius: 12px;
-      padding: 12px;
-      background-color: $color-background-neutral-0;
+      color: var(--color-text-main);
+      border: var(--color-border-1) solid 2px;
+      border-radius: var(--input-border-radius);
+      padding: var(--input-padding);
+      background-color: var(--color-background-neutral-0);
 
       &.has_error {
-        border: $color-semantic-critical solid 2px;
+        border: var(--color-semantic-critical) solid 2px;
       }
 
       &.has_icon {
@@ -47,7 +47,7 @@
 
   &_error {
     input {
-      border: $color-semantic-critical solid 1px;
+      border: var(--color-semantic-critical) solid 1px;
     }
   }
 }
@@ -55,7 +55,7 @@
 .tool_tip {
   margin-left: 10px;
   svg {
-    stroke: $color-interactions-menu;
+    stroke: var(--color-interactions-menu);
   }
 }
 
@@ -64,16 +64,16 @@
 }
 
 .error_message {
-  @include font-size(16);
-  color: $color-semantic-critical;
+  font-size: var(--input-info-font-size);
+  color: var(--color-semantic-critical);
   margin-top: 6px;
   line-height: 24px;
 }
 
 .info {
-  @include font-size(16);
+  font-size: var(--input-info-font-size);
   margin-top: 6px;
-  color: $color-text-subtle;
+  color: var(--color-text-subtle);
   line-height: 24px;
 }
 
@@ -85,15 +85,15 @@
 
 .icon_success {
   @include icon();
-  stroke: $color-semantic-success;
+  stroke: var(--color-semantic-success);
 }
 
 .icon_error {
   @include icon();
-  stroke: $color-semantic-critical;
+  stroke: var(--color-semantic-critical);
 }
 
 .icon_default {
   @include icon();
-  stroke: $color-text-info;
+  stroke: var(--color-text-info);
 }

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -47,7 +47,7 @@ type TextAreaPropsT = {
   onBlur?: Function;
   onFocus?: Function;
   onChange?: Function;
-  classProp?: string;
+  className?: string;
 };
 
 const TextArea = forwardRef(
@@ -59,7 +59,7 @@ const TextArea = forwardRef(
       toolTip,
       name,
       info = '',
-      classProp = '',
+      className = '',
       onChange,
       disabled,
       onBlur,
@@ -166,14 +166,14 @@ const TextArea = forwardRef(
       <div
         className={`${styles.text_area_wrapper}  ${
           showError ? styles.text_area_error : null
-        } ${classProp}`}
+        } ${className}`}
       >
         {showLabel && (
           <label className={styles.label}>
             {label}
             <span> {required && showRequired ? '*' : ''}</span>
             {toolTip && (
-              <ToolTip description={toolTip} classProp={styles.tool_tip}>
+              <ToolTip description={toolTip} className={styles.tool_tip}>
                 <Icon name="info" />
               </ToolTip>
             )}
@@ -201,7 +201,7 @@ const TextArea = forwardRef(
           ></textarea>
 
           {icon ? (
-            <Icon name={icon} classProp={styles['icon_' + iconColor]} />
+            <Icon name={icon} className={styles['icon_' + iconColor]} />
           ) : null}
         </div>
 

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -34,6 +34,7 @@ type TextAreaPropsT = {
   disabled?: boolean;
   validator?: Function;
   required?: boolean;
+  showRequired?: boolean;
   isError?: boolean;
   customErrorMessage?: string;
   maxLength?: number;
@@ -65,6 +66,7 @@ const TextArea = forwardRef(
       onFocus,
       validator = () => true,
       required = false,
+      showRequired = true,
       isError,
       customErrorMessage,
       maxLength,
@@ -169,7 +171,7 @@ const TextArea = forwardRef(
         {showLabel && (
           <label className={styles.label}>
             {label}
-            <span> {required ? '*' : ''}</span>
+            <span> {required && showRequired ? '*' : ''}</span>
             {toolTip && (
               <ToolTip description={toolTip} classProp={styles.tool_tip}>
                 <Icon name="info" />

--- a/src/components/ToolTip/ToolTip.module.scss
+++ b/src/components/ToolTip/ToolTip.module.scss
@@ -1,5 +1,4 @@
 @use '../../styles/core/boilerplate.scss'as *;
-$tip-width: 250px;
 
 .wrapper {
   position: relative;
@@ -7,13 +6,17 @@ $tip-width: 250px;
 }
 
 .description {
-  @include body-sm();
+  font-family: var(--font-primary);
+  font-size: var(--tooltip-font-size);
+  font-weight: var(--tooltip-font-weight);
+  letter-spacing: 0;
+  line-height: 25px;
   display: block;
   z-index: 2;
   padding: 10px;
-  min-width: $tip-width;
-  max-width: $tip-width;
-  width: $tip-width;
+  min-width: var(--tooltip-width);
+  max-width: var(--tooltip-width);
+  width: var(--tooltip-width);
   border-radius: 12px;
   padding: 14px;
   box-shadow: $drop-shadow;

--- a/src/components/ToolTip/ToolTip.tsx
+++ b/src/components/ToolTip/ToolTip.tsx
@@ -11,7 +11,7 @@ type ToolTipPropsT = {
   location?: ToolTipLocationT;
   category?: ToolTipCategoriesT;
   width?: string;
-  classProp?: string;
+  className?: string;
 };
 
 const ToolTip = ({
@@ -20,7 +20,7 @@ const ToolTip = ({
   location = 'top',
   category = 'primary',
   width = '250px',
-  classProp = '',
+  className = '',
 }: ToolTipPropsT) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -54,7 +54,7 @@ const ToolTip = ({
         </style>
         <FadeIn visible={isOpen}>
           <p
-            className={`${classProp} ${styles.description} ${
+            className={`${className} ${styles.description} ${
               styles[category]
             } ${width && 'localOverride'}`}
           >

--- a/src/components/ToolTip/ToolTip.tsx
+++ b/src/components/ToolTip/ToolTip.tsx
@@ -10,6 +10,7 @@ type ToolTipPropsT = {
   description: string;
   location?: ToolTipLocationT;
   category?: ToolTipCategoriesT;
+  width?: string;
   classProp?: string;
 };
 
@@ -18,6 +19,7 @@ const ToolTip = ({
   description,
   location = 'top',
   category = 'primary',
+  width = '250px',
   classProp = '',
 }: ToolTipPropsT) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -43,9 +45,18 @@ const ToolTip = ({
 
       {/* Tool Tip  */}
       <div className={`${styles.container} ${styles[location]}`}>
+        <style>
+          {`
+          .localOverride {
+            --tooltip-width: ${width}; !important;
+          }
+        `}
+        </style>
         <FadeIn visible={isOpen}>
           <p
-            className={`${classProp} ${styles.description} ${styles[category]}`}
+            className={`${classProp} ${styles.description} ${
+              styles[category]
+            } ${width && 'localOverride'}`}
           >
             {description}
           </p>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,7 @@
 export { default as Avatar } from './Avatar';
 export { default as Badge, type BadgeCategoriesT } from './Badge';
 export { default as Pill } from './Pill';
-export { default as Dropdown, type AlignmentT, type dropdownT } from './Dropdown';
+export { default as Dropdown, type AlignmentT, type DropdownT } from './Dropdown';
 export {
   default as Button,
   type ButtonT,

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -24,7 +24,7 @@ const Template: ComponentStory<typeof Modal> = (args) => {
 
   const ModalContent = () => (
     <>
-      <h1 className="mb-12">Modal Title</h1>
+      <h1 className="mb-12px">Modal Title</h1>
       <p>Modal Paragraph</p>
       <div className="flex-justify-end">
         <Button

--- a/src/stories/Notification.stories.tsx
+++ b/src/stories/Notification.stories.tsx
@@ -104,7 +104,7 @@ export type NotifcationStoryPropsT = {
   location?: NotificationLocationT;
   pauseOnHover?: boolean;
   category: CategoryT;
-  classProp?: string;
+  className?: string;
 };
 
 const NotifcationStory = ({
@@ -122,7 +122,7 @@ const NotifcationStory = ({
   location = 'top_right',
   pauseOnHover = true,
   category,
-  classProp = '',
+  className = '',
 }: NotifcationStoryPropsT) => {
   return <></>;
 };
@@ -188,7 +188,7 @@ const Template: ComponentStory<typeof NotifcationStory> = (args) => {
 // PRIMARY BUTTON
 export const Main = Template.bind({});
 Main.args = {
-  classProp: '',
+  className: '',
   title: 'Lorem ipsum dolor sit amet',
   description:
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.',

--- a/src/stories/ToolTip.stories.tsx
+++ b/src/stories/ToolTip.stories.tsx
@@ -43,6 +43,7 @@ const Template: ComponentStory<typeof ToolTip> = (args) => {
           location={args.location}
           category={args.category}
           description={args.description}
+          width={args.width}
         >
           <Button label="tip button" text="Button With Tip" />
         </ToolTip>
@@ -56,6 +57,7 @@ const Template: ComponentStory<typeof ToolTip> = (args) => {
           location={args.location}
           category={args.category}
           description={args.description}
+          width={args.width}
         >
           <Button label="tip button" text="Button With Tip" />
         </ToolTip>

--- a/src/styles/core/variables.scss
+++ b/src/styles/core/variables.scss
@@ -5,6 +5,8 @@ $font-size-base: 16; // base size in px
 $primary-font: var(--font-primary);
 $secondary-font: var(--font-seondary);
 $backup-font: var(--font-backup);
+$font-primary-weight: var(--font-primary-weight);
+$font-secondary-weight: var(--font-secondary-weight);
 
 // ---------------------------------
 //  Colors
@@ -153,3 +155,19 @@ $container-max-width: 1440px;
 $drop-shadow: 0 3px 8px rgba(#000, 0.3);
 $drop-shadow-right: 3px 3px 8px rgba(#000, 0.3);
 $drop-shadow-light: 0 3px 8px rgba(#000, 0.05);
+
+/**
+Inputs
+**/
+$input-label-font-size: var(--input-label-font-size);
+$input-label-font-weight: var(--input-label-font-weight);
+$input-font-size: var(--input-font-size);
+$input-info-font-size: var(--input-info-font-size);
+$input-border-radius: var(--input-border-radius);
+$input-padding: var(--input-padding);
+
+/**
+Dropdown
+**/
+$dropdown-margin-top: var(--dropdown-margin-top);
+$dropdown-border-radius: var(--dropdown-border-radius);

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -3,21 +3,86 @@
 
 :root {
   /**
-  BUTTON LAYOUT
-  **/
-  --button-border-radius: 20px;
-  --button-border-stroke: 2px;
-}
-
-main[data-theme='light'],
-:root {
-  /**
   FONTS
   **/
   --font-primary: 'Inter';
   --font-secondary: 'Space Grotesk';
   --font-backup: 'Arial';
 
+  --font-primary-weight: 500;
+  --font-secondary-weight: 700;
+
+  /**
+  BUTTON
+  **/
+  --button-font-size: 0.875rem;
+  --button-font-weight: 500;
+  --button-border-radius: 20px;
+  --button-border-stroke: 2px;
+  --button-padding-large: 12px 18px;
+  --button-padding-large-round: 12px;
+  --button-padding-medium: 8px 16px;
+  --button-padding-medium-round: 8px;
+  --button-padding-small: 6px 12px;
+  --button-padding-small-round: 6px;
+
+  /**
+  COPY BUTTON
+  **/
+  --copy-button-font-size: 0.875rem;
+  --copy-button-font-weight: 500;
+
+  /**
+  CHECKBOX
+  **/
+  --checkbox-label-font-size: 0.875rem;
+  --checkbox-label-font-weight: 500;
+
+  /**
+  INPUTS
+  **/
+  --input-label-font-size: 0.875rem;
+  --input-label-font-weight: 600;
+  --input-font-size: 0.875rem;
+  --input-info-font-size: 0.875rem;
+  --input-border-radius: 12px;
+  --input-padding: 12px;
+
+  /**
+  DROPDOWN
+  **/
+  --dropdown-margin-top: 12px;
+  --dropdown-border-radius: 4px;
+
+  /**
+  BADGE
+  **/
+  --badge-font-size: 0.875rem;
+  --badge-font-weight: 500;
+  --badge-padding: 5px 12px;
+  --badge-border-radius: 56px;
+
+  /**
+  RADIO
+  **/
+  --radio-label-font-size: 0.875rem;
+  --radio-label-font-weight: 500;
+
+  /**
+  SWITCH
+  **/
+  --switch-font-weight: 500;
+
+  /**
+  TOOLTIP
+  **/
+  --tooltip-font-size: 0.875rem;
+  --tooltip-font-weight: 500;
+  --tooltip-width: 250px;
+}
+
+main[data-theme='light'],
+:root {
   /**
   PRIMARY INTERACTION
   **/
@@ -118,17 +183,23 @@ main[data-theme='light'],
   --color-interactions-menu: #000000;
   --color-interactions-menu-hover: #2f2f2f;
   --color-interactions-menu-inactive: #757575;
+
+  /**
+  Badge
+  **/
+  --color-badge-primary-bg: #000000;
+  --color-badge-primary-text: #ffffff;
+  --color-badge-secondary-bg: #ffffff;
+  --color-badge-secondary-text: #000000;
+
+  /**
+  BUTTON
+  **/
+  --copy-button-text-color: #757575;
 }
 
 // PLACE HOLDER FOR DARK VALUES
 main[data-theme='dark'] {
-  /**
-  FONTS
-  **/
-  --font-primary: 'Inter';
-  --font-secondary: 'Space Grotesk';
-  --font-backup: 'Arial';
-
   /**
   PRIMARY INTERACTION
   **/
@@ -228,4 +299,17 @@ main[data-theme='dark'] {
   --color-interactions-menu: #ffffff;
   --color-interactions-menu-hover: #2f2f2f;
   --color-interactions-menu-inactive: #757575;
+
+  /**
+  Badge
+  **/
+  --color-badge-primary-bg: #ffffff;
+  --color-badge-primary-text: #000000;
+  --color-badge-secondary-bg: #000000;
+  --color-badge-secondary-text: #ffffff;
+
+  /**
+  BUTTON
+  **/
+  --copy-button-text-color: #ffffff;
 }

--- a/src/styles/tools/utility.scss
+++ b/src/styles/tools/utility.scss
@@ -244,7 +244,7 @@ $unit: 'px';
   **/
 
   // Padding: General
-  .p-#{$size} {
+  .p-#{$size}#{$unit} {
     padding: #{$size}#{$unit};
     &-dt {
       @include mobile-up {
@@ -259,7 +259,7 @@ $unit: 'px';
   }
 
   // Padding: Horizontal
-  .px-#{$size} {
+  .px-#{$size}#{$unit} {
     padding-left: #{$size}#{$unit};
     padding-right: #{$size}#{$unit};
     &-dt {
@@ -277,7 +277,7 @@ $unit: 'px';
   }
 
   // Padding: Vertical
-  .py-#{$size} {
+  .py-#{$size}#{$unit} {
     padding-top: #{$size}#{$unit};
     padding-bottom: #{$size}#{$unit};
     &-dt {
@@ -295,7 +295,7 @@ $unit: 'px';
   }
 
   // Padding: Top
-  .pt-#{$size} {
+  .pt-#{$size}#{$unit} {
     padding-top: #{$size}#{$unit};
     &-dt {
       @include mobile-up {
@@ -310,7 +310,7 @@ $unit: 'px';
   }
 
   // Padding: bottom
-  .pb-#{$size} {
+  .pb-#{$size}#{$unit} {
     padding-bottom: #{$size}#{$unit};
     &-dt {
       @include mobile-up {
@@ -325,7 +325,7 @@ $unit: 'px';
   }
 
   // Padding: Right
-  .pr-#{$size} {
+  .pr-#{$size}#{$unit} {
     padding-right: #{$size}#{$unit};
     &-dt {
       @include mobile-up {
@@ -340,7 +340,7 @@ $unit: 'px';
   }
 
   // Padding: Left
-  .pl-#{$size} {
+  .pl-#{$size}#{$unit} {
     padding-left: #{$size}#{$unit};
     &-dt {
       @include mobile-up {
@@ -359,7 +359,7 @@ $unit: 'px';
   **/
 
   // Margin: General
-  .m-#{$size} {
+  .m-#{$size}#{$unit} {
     margin: #{$size}#{$unit};
     &-dt {
       @include mobile-up {
@@ -374,7 +374,7 @@ $unit: 'px';
   }
 
   // Margin: Horizontal
-  .mx-#{$size} {
+  .mx-#{$size}#{$unit} {
     margin-left: #{$size}#{$unit};
     margin-right: #{$size}#{$unit};
     &-dt {
@@ -392,7 +392,7 @@ $unit: 'px';
   }
 
   // Margin: Vertical
-  .my-#{$size} {
+  .my-#{$size}#{$unit} {
     margin-top: #{$size}#{$unit};
     margin-bottom: #{$size}#{$unit};
     &-dt {
@@ -410,7 +410,7 @@ $unit: 'px';
   }
 
   // Margin: Top
-  .mt-#{$size} {
+  .mt-#{$size}#{$unit} {
     margin-top: #{$size}#{$unit};
     &-dt {
       @include mobile-up {
@@ -425,7 +425,7 @@ $unit: 'px';
   }
 
   // Margin: Top
-  .mb-#{$size} {
+  .mb-#{$size}#{$unit} {
     margin-bottom: #{$size}#{$unit};
     &-dt {
       @include mobile-up {
@@ -440,7 +440,7 @@ $unit: 'px';
   }
 
   // Margin: Right
-  .mr-#{$size} {
+  .mr-#{$size}#{$unit} {
     margin-right: #{$size}#{$unit};
     &-dt {
       @include mobile-up {
@@ -455,7 +455,7 @@ $unit: 'px';
   }
 
   // Margin: Left
-  .ml-#{$size} {
+  .ml-#{$size}#{$unit} {
     margin-left: #{$size}#{$unit};
     &-dt {
       @include mobile-up {


### PR DESCRIPTION
Lilypad was created for a specific purpose - to create a clean user interface that was friendly to a consumer audience. Though I do not want to stray away from this, it has been obvious lilypads customizability is too limited and needs additional CSS vars to give the developer more freedom in truly owning a component. This PR focuses on adding additional CSS vars for font sizes, weights, and overall padding and space consumption so a more utility-focused project can still use the components adequately. 

- Adding a custom Icon for buttons: using the icon prop for dual purposes ( IconT and React Component)  was a great idea however in the process we lost Type suggestions on the provided icons making that too much of a guessing game.
- Adding Variables for many of the component's fonts, font weights, and padding.
- Giving the tooltip a width prop
- Adding prop to give the developer freedom to show the required astric or not on inputs. 
 